### PR TITLE
revise(stream): drain the process stream on exit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,12 @@ keywords = ["tokio", "stream", "async-stream", "process"]
 
 [dependencies]
 tap          = "1.0.1"
-futures      = "0.3.21"
-tokio        = { version = "1.18.0", features = [ "rt-multi-thread", "macros", "process"] }
-tokio-stream = { version = "0.1.8", features = ["io-util"] }
-async-stream = "0.3.3"
-serde = { version = "1.0.137", features = ["derive"], optional = true }
-async-trait = "0.1.56"
+futures      = "0.3"
+tokio        = { version = "1", features = [ "rt-multi-thread", "macros", "process"] }
+tokio-stream = { version = "0.1", features = ["io-util"] }
+async-stream = "0.3"
+serde = { version = "1.0", features = ["derive"], optional = true }
+async-trait = "0.1"
 
 [features]
 default = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,10 +96,9 @@ pub trait ProcessExt {
                                     Some(code) => yield Exit(format!("{code}")),
                                     None => yield Error("Unable to get exit code".into()),
                                 }
-                                break;
-
                             }
                         }
+                        break;
                     },
                     _ = abort.notified() => {
                         match child.start_kill() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,21 +79,26 @@ pub trait ProcessExt {
         let stdout_stream = into_stream(stdout, true);
         let stderr_stream = into_stream(stderr, false);
         let mut std_stream = tokio_stream::StreamExt::merge(stdout_stream, stderr_stream);
-
         let stream = stream! {
             loop {
                 use ProcessItem::*;
                 tokio::select! {
                     Some(output) = std_stream.next() => yield output,
-                    status = child.wait() => match status {
-                        Err(err) => yield Error(err.to_string()),
-                        Ok(status) => {
-                            match status.code() {
-                                Some(code) => yield Exit(format!("{code}")),
-                                None => yield Error("Unable to get exit code".into()),
-                            }
-                            break;
+                    status = child.wait() => {
+                        // Drain the stream before exiting
+                        while let Some(output) = std_stream.next().await {
+                            yield output
+                        }
+                        match status {
+                            Err(err) => yield Error(err.to_string()),
+                            Ok(status) => {
+                                match status.code() {
+                                    Some(code) => yield Exit(format!("{code}")),
+                                    None => yield Error("Unable to get exit code".into()),
+                                }
+                                break;
 
+                            }
                         }
                     },
                     _ = abort.notified() => {


### PR DESCRIPTION
I found this bug when I was trying to use zcat in rust
I spawned a process stream `zcat`, then spawned a tokio task, which feeds data into stdin of the process
However, when exiting, I received no output from zcat.

I inspected process-stream. It would be possible to exit first without checking and fully draining stdout and stderr.

