### PR TITLE
fix(command): Bugfixes around command handling and docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "process-stream"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 description = "Thin wrapper around [`tokio::process`] to make it streamable"
 authors = ["tami5 "]
@@ -12,9 +12,9 @@ categories = ["asynchronous"]
 keywords = ["tokio", "stream", "async-stream", "process"]
 
 [dependencies]
-tap          = "1.0.1"
-futures      = "0.3"
-tokio        = { version = "1", features = [ "rt-multi-thread", "macros", "process"] }
+tap = "1.0.1"
+futures = "0.3"
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "process"] }
 tokio-stream = { version = "0.1", features = ["io-util"] }
 async-stream = "0.3"
 serde = { version = "1.0", features = ["derive"], optional = true }
@@ -22,4 +22,4 @@ async-trait = "0.1"
 
 [features]
 default = []
-serde = [ "dep:serde" ]
+serde = ["dep:serde"]

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ use std::io;
 
 #[tokio::main]
 async fn main() -> io::Result<()> {
-    let mut long_process = Process::new("/bin/app");
+    let mut long_process = Process::new("cat");
 
     let mut stream = long_process.spawn_and_stream()?;
 
@@ -91,7 +91,7 @@ async fn main() -> io::Result<()> {
     });
 
     // process some outputs
-    tokio::time::sleep(std::time::Duration::new(10, 0)).await;
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 
     // close the process
     long_process.abort();

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ use std::io;
 
 #[tokio::main]
 async fn main() -> io::Result<()> {
-    let ls_home: Process = vec!["/bin/ls", "."].into();
+    let mut ls_home: Process = vec!["/bin/ls", "."].into();
 
     let mut stream = ls_home.spawn_and_stream()?;
 
@@ -88,13 +88,13 @@ async fn main() -> io::Result<()> {
       while let Some(output) = stream.next().await {
         println!("{output}")
       }
-    })
+    });
 
     // process some outputs
     tokio::time::sleep(std::time::Duration::new(10, 0)).await;
 
     // close the process
-    long_process.kill().await;
+    long_process.abort();
 
     Ok(())
 }
@@ -103,9 +103,11 @@ async fn main() -> io::Result<()> {
 ### Communicate with running process
 ```rust
 use process_stream::{Process, ProcessExt, StreamExt};
+use tokio::io::AsyncWriteExt;
+use std::process::Stdio;
 
 #[tokio::main]
-async fn main() -> io::Result<()> {
+async fn main() -> std::io::Result<()> {
     let mut process: Process = Process::new("sort");
 
     // Set stdin (by default is set to null)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,12 +50,12 @@ pub trait ProcessExt {
         let stderr = self.get_stderr().take().unwrap();
         let command = self.get_command();
 
-        #[cfg(widnows)]
+        #[cfg(windows)]
         command.creation_flags(0x08000000);
 
         command.stdin(stdin);
-        command.stderr(stdout);
-        command.stdout(stderr);
+        command.stdout(stdout);
+        command.stderr(stderr);
         command
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,76 +293,11 @@ mod tests {
     use std::io::Result;
 
     #[tokio::test]
-    async fn test_from_vector() -> Result<()> {
-        let mut stream = Process::from(vec![
-            "xcrun",
-            "simctl",
-            "launch",
-            "--terminate-running-process",
-            "--console",
-            "booted",
-            "tami5.Wordle",
-        ])
-        .spawn_and_stream()
-        .unwrap();
-
-        while let Some(output) = stream.next().await {
-            println!("{output}")
-        }
-        Ok(())
-    }
-
-    #[tokio::test]
     async fn test_from_path() -> Result<()> {
         let mut process: Process = "/bin/ls".into();
 
         let outputs = process.spawn_and_stream()?.collect::<Vec<_>>().await;
         println!("{outputs:#?}");
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_new() -> Result<()> {
-        let mut process = Process::new("xcrun");
-
-        process.args(&[
-            "simctl",
-            "launch",
-            "--terminate-running-process",
-            "--console",
-            "booted",
-            "tami5.Wordle",
-        ]);
-
-        let mut stream = process.spawn_and_stream()?;
-
-        while let Some(output) = stream.next().await {
-            println!("{output:#?}")
-        }
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_abort() -> Result<()> {
-        let mut process = Process::new("xcrun");
-
-        process.args(&[
-            "/Users/tami5/Library/Caches/Xbase/swift_Control/Debug/Control.app/Contents/MacOS/Control",
-        ]);
-
-        let mut stream = process.spawn_and_stream()?;
-        tokio::spawn(async move {
-            while let Some(output) = stream.next().await {
-                println!("{output}")
-            }
-        });
-
-        tokio::time::sleep(std::time::Duration::new(5, 0)).await;
-
-        process.abort();
-
-        tokio::time::sleep(std::time::Duration::new(5, 0)).await;
-
         Ok(())
     }
 


### PR DESCRIPTION
There are a few issues in the command handling:
- `stdout` and `stderr` got mixed up in the constructor
- `cfg[windows]` was misspelled
- the doc tests were not up-to-date