### PR TITLE
Enable stricter clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,38 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 [features]
 default = []
 serde = ["dep:serde"]
+
+[lints.clippy]
+all = "deny"
+pedantic = "deny"
+nursery = "deny"
+match_same_arms = { level = "allow", priority = 1 }
+
+[lints.rust]
+# Groups
+warnings = "deny"
+future-incompatible = "deny"
+nonstandard-style = "deny"
+rust-2018-idioms = "deny"
+rust-2021-compatibility = "deny"
+rust-2024-compatibility = "deny"
+unused = "deny"
+
+# Individual lints that deserve special attention
+invalid-html-tags = "deny"
+absolute-paths-not-starting-with-crate = "deny"
+anonymous-parameters = "deny"
+macro-use-extern-crate = "deny"
+missing-copy-implementations = "deny"
+missing-debug-implementations = "deny"
+missing-docs = "deny"
+semicolon-in-expressions-from-macros = "deny"
+unreachable-pub = "deny"
+variant-size-differences = "deny"
+unsafe-code = "deny"
+invalid-value = "deny"
+missing-abi = "deny"
+large-assignments = "deny"
+explicit-outlives-requirements = "deny"
+trivial-casts = "deny"
+trivial-numeric-casts = "deny"

--- a/src/item.rs
+++ b/src/item.rs
@@ -17,9 +17,9 @@ impl Deref for ProcessItem {
 
     fn deref(&self) -> &Self::Target {
         match self {
-            ProcessItem::Output(s) => s,
-            ProcessItem::Error(s) => s,
-            ProcessItem::Exit(s) => s,
+            Self::Output(s) => s,
+            Self::Error(s) => s,
+            Self::Exit(s) => s,
         }
     }
 }
@@ -54,7 +54,7 @@ impl ProcessItem {
     ///
     /// [`Output`]: ProcessItem::Output
     #[must_use]
-    pub fn is_output(&self) -> bool {
+    pub const fn is_output(&self) -> bool {
         matches!(self, Self::Output(..))
     }
 
@@ -62,7 +62,7 @@ impl ProcessItem {
     ///
     /// [`Error`]: ProcessItem::Error
     #[must_use]
-    pub fn is_error(&self) -> bool {
+    pub const fn is_error(&self) -> bool {
         matches!(self, Self::Error(..))
     }
 
@@ -70,7 +70,7 @@ impl ProcessItem {
     ///
     /// [`Exit`]: ProcessItem::Exit
     #[must_use]
-    pub fn is_exit(&self) -> bool {
+    pub const fn is_exit(&self) -> bool {
         matches!(self, Self::Exit(..))
     }
 
@@ -83,7 +83,8 @@ impl ProcessItem {
     }
 
     /// Return exit code if [`ProcessItem`] is [`ProcessItem::Exit`]
-    pub fn as_exit(&self) -> Option<&String> {
+    #[must_use]
+    pub const fn as_exit(&self) -> Option<&String> {
         if let Self::Exit(v) = self {
             Some(v)
         } else {
@@ -92,7 +93,8 @@ impl ProcessItem {
     }
 
     /// Return inner reference [`String`] value if [`ProcessItem`] is [`ProcessItem::Error`]
-    pub fn as_error(&self) -> Option<&String> {
+    #[must_use]
+    pub const fn as_error(&self) -> Option<&String> {
         if let Self::Error(v) = self {
             Some(v)
         } else {
@@ -101,7 +103,8 @@ impl ProcessItem {
     }
 
     /// Return inner reference [`String`] value if [`ProcessItem`] is [`ProcessItem::Output`]
-    pub fn as_output(&self) -> Option<&String> {
+    #[must_use]
+    pub const fn as_output(&self) -> Option<&String> {
         if let Self::Output(v) = self {
             Some(v)
         } else {


### PR DESCRIPTION
This fixes some more linting issues. Overall, these are just changes that clippy suggests at the highest level, which I think makes sense for a fundamental library like this.

Also, I renamed `_spawn_and_stream` to `spawn_and_stream()` as an underscore in front
of a method name typically indicates that a variable or function is not used.
However, this is not the case here.

For more info, see this clippy lint documentation:
https://rust-lang.github.io/rust-clippy/master/index.html#used_underscore_items