### PR TITLE
 Improve clarity in ProcessItem conversion logic

### DIFF
--- a/src/item.rs
+++ b/src/item.rs
@@ -40,9 +40,9 @@ impl fmt::Debug for ProcessItem {
     }
 }
 impl From<(bool, io::Result<String>)> for ProcessItem {
-    fn from(v: (bool, io::Result<String>)) -> Self {
-        match v.1 {
-            Ok(line) if v.0 => Self::Output(line),
+    fn from((is_stdout, line): (bool, io::Result<String>)) -> Self {
+        match line {
+            Ok(line) if is_stdout => Self::Output(line),
             Ok(line) => Self::Error(line),
             Err(e) => Self::Error(e.to_string()),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,7 +280,7 @@ where
     std.pipe(BufReader::new)
         .lines()
         .pipe(LinesStream::new)
-        .map(move |v| T::from((is_stdout, v)))
+        .map(move |line| T::from((is_stdout, line)))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
I think it is easier to understand what's going on in the  From logic for ProcessItem if the tuple fields have named values.
 Alternatively, we could consider to convert this to a struct. I personally would prefer that, but it's definitely a matter of preference and I don't have a strong opinion on it. ;)